### PR TITLE
Set default options to empty object

### DIFF
--- a/packages/google-cloud-storage/src/google-cloud-storage.ts
+++ b/packages/google-cloud-storage/src/google-cloud-storage.ts
@@ -30,7 +30,7 @@ export class GoogleCloudStorageAdapter implements StorageAdapter {
     private readonly prefixer: PathPrefixer;
     constructor(
         private readonly bucket: Bucket,
-        readonly options: GoogleCloudStorageAdapterOptions,
+        readonly options: GoogleCloudStorageAdapterOptions = {},
         readonly visibilityHandling: VisibilityHandlingForGoogleCloudStorage = new UniformBucketLevelAccessVisibilityHandling()
     ) {
         this.prefixer = new PathPrefixer(options.prefix ?? '');


### PR DESCRIPTION
The `prefix` is optional at the moment, but the object is not. I didn't have to use the `prefix` (I think), but had to specify the empty object. This might be a design choice and later on we might need required options here (although I doubt it after working a pretty long time with GCS). Anyway, this would make my implementation slightly cleaner.