### PR TITLE
chore: Update docs

### DIFF
--- a/packages/file-storage/README.md
+++ b/packages/file-storage/README.md
@@ -75,7 +75,7 @@ import {LocalStorageAdapter} from '@flystorage/local-fs';
  **/
 
 const rootDirectory = resolve(process.cwd(), 'my-files');
-const storage = new FileStorage(new LocalFileStorage(rootDirectory));
+const storage = new FileStorage(new LocalStorageAdapter(rootDirectory));
 
 /**
  * USAGE


### PR DESCRIPTION
Update the docs `LocalFileStorage` is deprecated and not used. Changed to `LocalStorageAdapter`.