### PR TITLE
Temporary URL Azure Storage Blob Adapter Options

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,3 +50,19 @@ services:
 #    ports:
 #      - "2121:21"
 #      - "21000-21010:21000-21010"
+
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite
+    profiles: ["azure"]
+    restart: unless-stopped
+    healthcheck:
+      test:
+        wget --no-verbose --tries=1 --spider http://localhost:10000/ || exit 1
+      interval: 10s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    ports:
+      - 10000:10000
+      - 10001:10001
+      - 10002:10002

--- a/packages/azure-storage-blob/src/azure-storage-blob.test.ts
+++ b/packages/azure-storage-blob/src/azure-storage-blob.test.ts
@@ -12,6 +12,10 @@ describe('AzureStorageBlobStorageAdapter', () => {
     const container = blobService.getContainerClient('flysystem');
     let storage: FileStorage;
 
+    beforeAll(async () => {
+        await container.createIfNotExists();
+    })
+
     beforeEach(() => {
         const testSegment = randomBytes(10).toString('hex');
         const adapter = new AzureStorageBlobStorageAdapter(

--- a/packages/azure-storage-blob/src/azure-storage-blob.test.ts
+++ b/packages/azure-storage-blob/src/azure-storage-blob.test.ts
@@ -2,7 +2,8 @@ import {BlobServiceClient} from "@azure/storage-blob";
 import {AzureStorageBlobStorageAdapter} from "./azure-storage-blob.js";
 import {randomBytes} from "crypto";
 import {FileStorage, Visibility, readableToString} from "@flystorage/file-storage";
-import * as https from "https";
+import fetch from "node-fetch";
+import { Readable } from "node:stream";
 
 const runSegment = process.env.AZURE_PREFIX ?? randomBytes(10).toString('hex');
 
@@ -167,14 +168,12 @@ describe('AzureStorageBlobStorageAdapter', () => {
     });
 });
 
-function naivelyDownloadFile(url: string): Promise<string> {
-    return new Promise((resolve, reject) => {
-        https.get(url, async res => {
-            if (res.statusCode !== 200) {
-                reject(new Error(`Not able to download the file from ${url}, response status [${res.statusCode}]`));
-            } else {
-                resolve(await readableToString(res));
-            }
-        });
-    });
+async function naivelyDownloadFile(url: string): Promise<string> {
+    const res = await fetch(url);
+
+    if (res.status !== 200 || !res.body) {
+        throw new Error(`Not able to download the file from ${url}, response status [${res.status}]`);
+    } else {
+        return await readableToString(Readable.from(res.body));
+    }
 }

--- a/packages/azure-storage-blob/src/azure-storage-blob.test.ts
+++ b/packages/azure-storage-blob/src/azure-storage-blob.test.ts
@@ -13,7 +13,7 @@ describe('AzureStorageBlobStorageAdapter', () => {
     let storage: FileStorage;
 
     beforeAll(async () => {
-        await container.createIfNotExists();
+        await container.createIfNotExists({ access: "container" });
     })
 
     beforeEach(() => {

--- a/packages/azure-storage-blob/src/azure-storage-blob.test.ts
+++ b/packages/azure-storage-blob/src/azure-storage-blob.test.ts
@@ -8,7 +8,9 @@ import { Readable } from "node:stream";
 const runSegment = process.env.AZURE_PREFIX ?? randomBytes(10).toString('hex');
 
 describe('AzureStorageBlobStorageAdapter', () => {
-    const blobService = BlobServiceClient.fromConnectionString(process.env.AZURE_DSN!);
+    const blobService = BlobServiceClient.fromConnectionString(
+        process.env.AZURE_DSN || "UseDevelopmentStorage=true;"
+    );
     const container = blobService.getContainerClient('flysystem');
     let storage: FileStorage;
 

--- a/packages/azure-storage-blob/src/azure-storage-blob.ts
+++ b/packages/azure-storage-blob/src/azure-storage-blob.ts
@@ -30,6 +30,7 @@ export type AzureStorageBlobStorageAdapterOptions = {
     ignoreVisibility?: boolean,
     ignoredVisibilityResponse?: string,
     deleteDirBatchSize?: number,
+    temporaryUrlOptions?: TemporaryUrlOptions,
 }
 
 export class AzureStorageBlobStorageAdapter implements StorageAdapter {
@@ -223,6 +224,7 @@ export class AzureStorageBlobStorageAdapter implements StorageAdapter {
         return await this.blockClient(path).generateSasUrl({
             expiresOn: normalizeExpiryToDate(options.expiresAt),
             permissions: BlobSASPermissions.parse('r'),
+            ...this.options.temporaryUrlOptions,
         });
     }
     async checksum(path: string, options: ChecksumOptions): Promise<string> {


### PR DESCRIPTION
Similar to the approach taken in the adapter options of `@flystorage/aws-s3`, this PR adds a `temporaryUrlOptions` option to the Azure Storage Blob Adapter options.

- Tests have been updated to allow HTTP as well as HTTPS for consistency with `ContainerClient.generateSasUrl`'s option to specify the `protocol` option with a value such as `SASProtocol.HttpsAndHttp` or `SASProtocol.Https`.
- Adds the [`azurite`](https://github.com/Azure/Azurite) to test against.
  - Run the Azurite container: `docker compose --profile azure up`
  - Run the tests against the Azurite container: `AZURE_DSN="UseDevelopmentStorage=true;" npm run jest`
