### PR TITLE
Add support for custom Cache-Control header

### DIFF
--- a/packages/aws-s3/src/aws-s3-file-storage.test.ts
+++ b/packages/aws-s3/src/aws-s3-file-storage.test.ts
@@ -130,6 +130,13 @@ describe('aws-s3 file storage', () => {
 
         expect(checksum).toEqual(expectedChecksum);
     });
+
+    test('it handles custom Cache-Control header', async() => {
+        await storage.write('cache.txt', 'some content', {cacheControl: "max-age=7200, public", visibility: Visibility.PUBLIC});
+        const url = await storage.publicUrl('cache.txt')
+        const res = await fetch(url);
+        expect(res.headers.get("Cache-Control")).toEqual("max-age=7200, public")
+    });
 });
 
 function naivelyDownloadFile(url: string): Promise<string> {

--- a/packages/aws-s3/src/aws-s3-storage-adapter.ts
+++ b/packages/aws-s3/src/aws-s3-storage-adapter.ts
@@ -370,6 +370,7 @@ export class AwsS3StorageAdapter implements StorageAdapter {
             ACL: options.visibility ? this.visibilityToAcl(options.visibility) : undefined,
             ContentType: mimeType,
             ContentLength: options.size,
+            CacheControl: options.cacheControl
         });
     }
 

--- a/packages/azure-storage-blob/src/azure-storage-blob.test.ts
+++ b/packages/azure-storage-blob/src/azure-storage-blob.test.ts
@@ -172,6 +172,13 @@ describe('AzureStorageBlobStorageAdapter', () => {
 
         expect(contents).toEqual('something');
     });
+
+    test('setting cache-control headers', async () => {
+        await storage.write('cachecontrol.txt', 'something', { cacheControl: 'max-age=3200, public' });
+        const url = await storage.publicUrl('cachecontrol.txt');
+        const res = await fetch(url);
+        expect(res.headers.get("Cache-Control")).toEqual('max-age=3200, public');
+    });
 });
 
 async function naivelyDownloadFile(url: string): Promise<string> {

--- a/packages/azure-storage-blob/src/azure-storage-blob.ts
+++ b/packages/azure-storage-blob/src/azure-storage-blob.ts
@@ -68,6 +68,7 @@ export class AzureStorageBlobStorageAdapter implements StorageAdapter {
             {
                 blobHTTPHeaders: {
                     blobContentType: mimeType,
+                    blobCacheControl: options.cacheControl
                 },
             },
         );

--- a/packages/file-storage/src/file-storage.ts
+++ b/packages/file-storage/src/file-storage.ts
@@ -117,6 +117,7 @@ export type VisibilityOptions = {
 export type WriteOptions = VisibilityOptions & MiscellaneousOptions & {
     mimeType?: string,
     size?: number,
+    cacheControl?: string,
 };
 export type CreateDirectoryOptions = MiscellaneousOptions & Pick<VisibilityOptions, 'directoryVisibility'> & {};
 export type PublicUrlOptions = MiscellaneousOptions & {};

--- a/packages/google-cloud-storage/src/google-cloud-storage.test.ts
+++ b/packages/google-cloud-storage/src/google-cloud-storage.test.ts
@@ -148,6 +148,13 @@ describe('GoogleCloudStorageAdapter', () => {
             expect(contents).toEqual('public contents');
         });
 
+        test('with a custom Cache-Control Header', async () => {
+            await storage.write('cache.txt', 'contents', {visibility: Visibility.PUBLIC, cacheControl: "max-age=9999, public"});
+            const url = await storage.publicUrl('cache.txt');
+            const res = await fetch(url);
+            expect (res.headers.get('Cache-Control')).toEqual('max-age=9999, public');
+        })
+
         test('using a temporary URL', async () => {
             await storage.write('path.txt', 'private contents', {
                 visibility: Visibility.PRIVATE,

--- a/packages/google-cloud-storage/src/google-cloud-storage.ts
+++ b/packages/google-cloud-storage/src/google-cloud-storage.ts
@@ -48,7 +48,8 @@ export class GoogleCloudStorageAdapter implements StorageAdapter {
                 contentType: mimeType,
                 predefinedAcl: options.visibility
                     ? this.visibilityHandling.visibilityToPredefinedAcl(options.visibility)
-                    : undefined
+                    : undefined,
+                metadata: options.cacheControl? {cacheControl: options.cacheControl} : undefined,
             });
 
         await pipeline(contents, writeStream);


### PR DESCRIPTION
This is only supported for public access on supported providers: azure, s3, gcs.

The intention is so that when hosting stuff for public access -logos etc.-, you can set the cache-control header and allow browsers to cache the content.

closes #36 