### PR TITLE
deep listing returns wrong results fix

### DIFF
--- a/packages/local-fs/src/local-file-storage.test.ts
+++ b/packages/local-fs/src/local-file-storage.test.ts
@@ -161,6 +161,20 @@ describe('LocalStorageAdapter', () => {
         expect(listing.map(l => l.type).sort()).toEqual(['directory', 'directory', 'file']);
     });
 
+    test('non deep and deep listing should have consistant and similar results', async () => {
+        await storage.write('file_1.txt', 'contents');
+        await storage.write('file_2.txt', 'contents');
+        await storage.createDirectory('directory_1');
+        await storage.createDirectory('directory_2');
+
+        const non_deep_listing = await storage.list('/', {deep: false}).toArray();
+        const deep_listing = await storage.list('/', {deep: true}).toArray();
+
+        expect(non_deep_listing).toHaveLength(4);
+        expect(deep_listing).toHaveLength(4);
+        expect(non_deep_listing).toEqual(deep_listing);
+    });
+
     test('filtering out directories for a deep listing', async () => {
         await storage.write('deeply/nested/directory.txt', 'contents');
 

--- a/packages/local-fs/src/local-file-storage.ts
+++ b/packages/local-fs/src/local-file-storage.ts
@@ -165,7 +165,7 @@ export class LocalStorageAdapter implements StorageAdapter {
         });
 
         for await (const item of entries) {
-            const itemPath = deep ? item.path : posix.join(item.path, item.name);
+            const itemPath = posix.join(item.path, item.name);
 
             yield this.mapStatToEntry(
                 item,


### PR DESCRIPTION
I really love and appreciate your work in this repo.
you are really helping the community.

## This PR fixes this issue:
When I use the list method in the storage object normally with deep as false I get the path results correctly
```js
storage.list('/', { deep: false });
```
```json
[
    {
        "path": "A3DQ46_Eticket.pdf",
        "type": "file",
        "isFile": true,
        "isDirectory": false
    },
    {
        "path": "malik",
        "type": "directory",
        "isFile": false,
        "isDirectory": true
    },
    {
        "path": "Screenshot from 2024-07-01 23-27-32.png",
        "type": "file",
        "isFile": true,
        "isDirectory": false
    }
]
```

but when I set the deep property to true. it returns an array of object with path property value without the file name part or the directory name part
```js
storage.list('/', { deep: true });
```
```json
[
    {
        "path": "",
        "type": "file",
        "isFile": true,
        "isDirectory": false
    },
    {
        "path": "",
        "type": "directory",
        "isFile": false,
        "isDirectory": true
    },
    {
        "path": "",
        "type": "file",
        "isFile": true,
        "isDirectory": false
    }
]
```

the issue is that when the user list with a deep property as true it adds only the path without the file name or the directory name part

so it will always ignore the last part of the path and keep the path.
so the path in deep listing is behaving as a location instead of a full path of a file or a directory