### PR TITLE
Expanded conditional to handle when stream is already destroyed

### DIFF
--- a/packages/file-storage/src/file-storage.ts
+++ b/packages/file-storage/src/file-storage.ts
@@ -465,7 +465,7 @@ export function normalizeExpiryToMilliseconds(expiresAt: ExpiresAt): number {
 }
 
 export async function closeReadable(body: Readable) {
-    if (body.closed) {
+    if (body.closed || body.destroyed) {
         return;
     }
 


### PR DESCRIPTION
We ran into an issue when using the `LocalStorageAdapter` that awaiting the write never returned. I discovered this was because the ReadableStream was destroyed and closed was undefined.

Resolves https://github.com/duna-oss/flystorage/issues/86